### PR TITLE
Fix problem in Windows and Mac

### DIFF
--- a/src/io/emmet/Emmet.java
+++ b/src/io/emmet/Emmet.java
@@ -2,6 +2,7 @@ package io.emmet;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
@@ -68,9 +69,9 @@ public class Emmet {
 		singleton = null;
 	}
 	
-	private InputStreamReader getReaderForLocalFile(String fileName) {
+	private InputStreamReader getReaderForLocalFile(String fileName) throws UnsupportedEncodingException {
 		InputStream is = this.getClass().getResourceAsStream(fileName);
-		return new InputStreamReader(is);
+		return new InputStreamReader(is, "UTF-8");
 	}
 	
 	private String readLocalFile(String fileName) {


### PR DESCRIPTION
Default encoding might not be "UTF-8" in Windows and Mac.
So, I add the encoding to argument for InputStreamReader.

Probably, this relates to #2.

Thanks.
