### PR TITLE
Fix problem that custom snippet doesn't work

### DIFF
--- a/src/org/lorenzos/emmet/editor/EmmetEditor.java
+++ b/src/org/lorenzos/emmet/editor/EmmetEditor.java
@@ -257,6 +257,9 @@ public class EmmetEditor implements IEmmetEditor {
 					tokenSequence.move(this.caretPosition - 1);
 					if (tokenSequence.moveNext()) {
 						this.setContentType(tokenSequence.language().mimeType());
+						if(matchesSyntax(MIME_SCSS, MIME_XSCSS, MIME_LESS, MIME_LESSCSS, MIME_XLESSCSS, MIME_SASS, MIME_XSASS)){
+							break;
+						}
 						tokenSequence = tokenSequence.embedded();
 					} else {
 						tokenSequence = null;


### PR DESCRIPTION
If get embedded language, scss file is recognized as css in NetBeans 7.4.
So, I think that we should not get embedded language in scss, sass and less file. 

Thanks.
